### PR TITLE
Fixed masthead

### DIFF
--- a/css/new-age.css
+++ b/css/new-age.css
@@ -135,7 +135,7 @@ header.masthead {
       border-radius: 3px; }
   @media (min-width: 992px) {
     header.masthead {
-      height: 100vh;
+      height: 950px;
       min-height: 775px;
       padding-top: 0;
       padding-bottom: 0; }


### PR DESCRIPTION
Masthead images are blocking the Tezbox logo as well as the navigation menu on screens with 992px or more (my laptop) and it's also omitting the words "with macos, Windows, *nix and iOS in development..." from under the Google Play icon. 

After the fix the background images are in the proper place and the text below the Google Play icon is back in view.